### PR TITLE
Fixed typo in constant DefaultConnectionSettingStringName

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusWebJobsBuilderExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Hosting
                 .ConfigureOptions<ServiceBusOptions>((config, path, options) =>
                 {
                     options.ConnectionString = config.GetConnectionString(Constants.DefaultConnectionStringName) ??
-                        config[Constants.DefaultConectionSettingStringName];
+                        config[Constants.DefaultConnectionSettingStringName];
 
                     IConfigurationSection section = config.GetSection(path);
                     section.Bind(options);

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Constants.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Constants.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         }
 
         public const string DefaultConnectionStringName = "ServiceBus";
-        public const string DefaultConectionSettingStringName = "AzureWebJobsServiceBus";
+        public const string DefaultConnectionSettingStringName = "AzureWebJobsServiceBus";
         public const string DynamicSku = "Dynamic";
         public const string AzureWebsiteSku = "WEBSITE_SKU";
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ServiceBusAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ServiceBusAccount.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                     {
                         throw new InvalidOperationException(
                             string.Format(CultureInfo.InvariantCulture, "Microsoft Azure WebJobs SDK ServiceBus connection string '{0}' is missing or empty.",
-                            Sanitizer.Sanitize(_connectionProvider.Connection) ?? Constants.DefaultConectionSettingStringName));
+                            Sanitizer.Sanitize(_connectionProvider.Connection) ?? Constants.DefaultConnectionSettingStringName));
                     }
                 }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Config/ServiceBusHostBuilderExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Config/ServiceBusHostBuilderExtensionsTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
                 var envPrpvider = (test.ImplementationInstance as ConfigurationRoot).Providers
                     .Single(x => x.GetType() == typeof(EnvironmentVariablesConfigurationProvider));
                 envPrpvider.Set("ConnectionStrings:" + Constants.DefaultConnectionStringName, defaultConnectionString);
-                envPrpvider.Set(Constants.DefaultConectionSettingStringName, sefaultConectionSettingString);
+                envPrpvider.Set(Constants.DefaultConnectionSettingStringName, sefaultConectionSettingString);
 
                 b.AddServiceBus();
             }, new Dictionary<string, string>());


### PR DESCRIPTION
This is a very simple fix for a typo in the name of the constant _DefaultConnectionSettingStringName_. The previous one was missing an "N" in the word Connection. A very small contribution, but everything helps :-) ...

Thanks.