### PR TITLE
Return valid string using MessageToStringConverter

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/MessageToStringConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/MessageToStringConverter.cs
@@ -47,13 +47,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
                 {
                     return input.GetBody<string>();
                 }
-                catch (Exception exception)
+                catch
                 {
-                    string contentType = input.ContentType ?? "null";
-                    string msg = string.Format(CultureInfo.InvariantCulture, "The Message with ContentType '{0}' failed to deserialize to a string with the message: '{1}'",
-                        contentType, exception.Message);
-
-                    throw new InvalidOperationException(msg, exception);
+                    // always possible to get a valid string from the message
+                    return Encoding.UTF8.GetString(input.Body, 0, input.Body.Length);
                 }
             }
             finally

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/MessageToStringConverterTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/MessageToStringConverterTests.cs
@@ -64,23 +64,21 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests
         }
 
         [Fact]
-        public async Task ConvertAsync_Throws_WithSerializedObject()
+        public async Task ConvertAsync_ReturnsExpectedResult_WithSerializedObject()
         {
 
             byte[] bytes;
             using (MemoryStream ms = new MemoryStream())
             {
-                DataContractBinarySerializer<TestObject>.Instance.WriteObject(ms, new TestObject() { Text = "Test" });
+                DataContractBinarySerializer<TestObject>.Instance.WriteObject(ms, new TestObject() { Text = "Test"});
                 bytes = ms.ToArray();
             }
             
             Message message = new Message(bytes);
 
             MessageToStringConverter converter = new MessageToStringConverter();
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => converter.ConvertAsync(message, CancellationToken.None));
-
-            Assert.IsType<SerializationException>(exception.InnerException);
-            Assert.StartsWith("The Message with ContentType 'null' failed to deserialize to a string with the message:", exception.Message);
+            string result = await converter.ConvertAsync(message, CancellationToken.None);
+            Assert.Equal(Encoding.UTF8.GetString(message.Body), result);
         }
 
         [Serializable]


### PR DESCRIPTION
Valid string is needed in `SimpleTriggerArgumentBinding`:
https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Triggers/TriggerArgumentBinding/SimpleTriggerArgumentBinding.cs#L78