### PR TITLE
Fixing ServiceBusTrigger binding data for POCOs

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,5 +4,6 @@
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="appService" value="https://www.myget.org/F/azure-appservice/api/v2/" />
+    <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
 
             // register our trigger binding provider
             ServiceBusTriggerAttributeBindingProvider triggerBindingProvider = new ServiceBusTriggerAttributeBindingProvider(_nameResolver, _options, _messagingProvider, _configuration, _loggerFactory, _converterManager);
-            context.AddBindingRule<ServiceBusTriggerAttribute>().BindToTrigger(triggerBindingProvider);
+            context.AddBindingRule<ServiceBusTriggerAttribute>()
+                .BindToTrigger(triggerBindingProvider);
 
             // register our binding provider
             ServiceBusAttributeBindingProvider bindingProvider = new ServiceBusAttributeBindingProvider(_nameResolver, _options, _configuration, _messagingProvider);

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
@@ -38,8 +38,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Sources" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.16" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Sources" Version="3.0.16" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/ServiceBusSessionsEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/ServiceBusSessionsEndToEndTests.cs
@@ -381,10 +381,11 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         private async Task Cleanup()
         {
-            List<Task> tasks = new List<Task>();
-
-            tasks.Add(ServiceBusSessionsTestHelper.CleanUpQueue(_connectionString, _queueName));
-            tasks.Add(ServiceBusSessionsTestHelper.CleanUpSubscription(_connectionString, _topicName, _subscriptionName));
+            var tasks = new List<Task>()
+            {
+                ServiceBusSessionsTestHelper.CleanUpQueue(_connectionString, _queueName),
+                ServiceBusSessionsTestHelper.CleanUpSubscription(_connectionString, _topicName, _subscriptionName)
+            };
 
             await Task.WhenAll(tasks);
         }
@@ -586,15 +587,15 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
         public static async Task CleanUpQueue(string connectionString, string queueName)
         {
-            await ClenaUpEntity(connectionString, queueName);
+            await CleanUpEntity(connectionString, queueName);
         }
 
         public static async Task CleanUpSubscription(string connectionString, string topicName, string subscriptionName)
         {
-            await ClenaUpEntity(connectionString, EntityNameHelper.FormatSubscriptionPath(topicName, subscriptionName));
+            await CleanUpEntity(connectionString, EntityNameHelper.FormatSubscriptionPath(topicName, subscriptionName));
         }
 
-        private static async Task ClenaUpEntity(string connectionString, string entityPAth)
+        private static async Task CleanUpEntity(string connectionString, string entityPAth)
         {
             var client = new SessionClient(connectionString, entityPAth, ReceiveMode.PeekLock);
             client.OperationTimeout = TimeSpan.FromSeconds(5);
@@ -603,7 +604,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
             try
             {
                 session = await client.AcceptMessageSessionAsync();
-                var messages = await session.ReceiveAsync(1000, TimeSpan.FromSeconds(5));
+                var messages = await session.ReceiveAsync(1000, TimeSpan.FromSeconds(1));
                 await session.CompleteAsync(messages.Select(m => m.SystemProperties.LockToken));
             }
             catch (ServiceBusException)

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/WebJobs.Extensions.ServiceBus.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/WebJobs.Extensions.ServiceBus.Tests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.14" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.16" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fix for Azure/azure-functions-servicebus-extension#44 in collaboration with @alrod.

Relies on the SDK fix https://github.com/Azure/azure-webjobs-sdk/pull/2423. Will need to pull in an updated SDK version with that fix as part of this commit.