### PR TITLE
Reduce default BatchOptions MaxMessageCount

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             // https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Constants.cs#L30
             BatchOptions = new BatchOptions()
             {
-                MaxMessageCount = 1000,
+                MaxMessageCount = 100,
                 OperationTimeout = TimeSpan.FromMinutes(1),
                 AutoComplete = true
             };


### PR DESCRIPTION
The original default MaxMessageCount of 1000 seems really high to me. Most users of Azure Functions will go with the defaults, so I'd like to see a conservative option here that balances memory consumption and performance. 
I chose 100 as a placeholder instead, but I'm open to reducing further if people think that's still high.
It would be great to get this changed before the defaults are documented in Azure Docs.
Thanks!