### PR TITLE
When ServiceBusOptions.ConnectionString is already set do not retrieve the connection string from web job configurations

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ServiceBusAccount.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ServiceBusAccount.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 if (string.IsNullOrEmpty(_connectionString))
                 {
                     _connectionString = _options.ConnectionString;
-                    if (_connectionProvider != null && !string.IsNullOrEmpty(_connectionProvider.Connection))
+                    if (_connectionProvider != null && !string.IsNullOrEmpty(_connectionProvider.Connection) && string.IsNullOrEmpty(_connectionString))
                     {
                         _connectionString = _configuration.GetWebJobsConnectionString(_connectionProvider.Connection);
                     }


### PR DESCRIPTION
For my use case i need to set connection string during start up

 builder.Services.PostConfigure<ServiceBusOptions>(options =>
{
                options.ConnectionString = "ConnectionString goes here read from configuration w/e ";
 });

similar approach is used by cosmos db trigger. If connection string is set on CosmosDBOptions local.settings.json will not be used.

https://github.com/Azure/azure-webjobs-sdk-extensions/blob/b7aa8f84c2b3c9065861fe955ce8180b9d19f939/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
