### PR TITLE
Convert ExpiresAtUtc to UTC time to mitigate serialization issue

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerBindingStrategy.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                 deliveryCounts[i] = messages[i].SystemProperties.DeliveryCount;
                 deadLetterSources[i] = messages[i].SystemProperties.DeadLetterSource;
                 lockTokens[i] = messages[i].SystemProperties.IsLockTokenSet ? messages[i].SystemProperties.LockToken : string.Empty;
-                expiresAtUtcs[i] = messages[i].ExpiresAtUtc;
+                //this is temporary until the Service Bus SDK addresses the missing timezone issue in case DateTime.MaxValue, github.com/Azure/azure-sdk-for-net/issues/15343
+                expiresAtUtcs[i] = messages[i].ExpiresAtUtc.ToUniversalTime();
                 enqueuedTimeUtcs[i] = messages[i].SystemProperties.EnqueuedTimeUtc;
                 messageIds[i] = messages[i].MessageId;
                 contentTypes[i] = messages[i].ContentType;
@@ -143,7 +144,8 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             SafeAddValue(() => bindingData.Add(nameof(value.SystemProperties.DeliveryCount), value.SystemProperties.DeliveryCount));
             SafeAddValue(() => bindingData.Add(nameof(value.SystemProperties.DeadLetterSource), value.SystemProperties.DeadLetterSource));
             SafeAddValue(() => bindingData.Add(nameof(value.SystemProperties.LockToken), value.SystemProperties.IsLockTokenSet ? value.SystemProperties.LockToken : string.Empty));
-            SafeAddValue(() => bindingData.Add(nameof(value.ExpiresAtUtc), value.ExpiresAtUtc));
+            //this is temporary until the Service Bus SDK addresses the missing timezone issue in case DateTime.MaxValue, github.com/Azure/azure-sdk-for-net/issues/15343
+            SafeAddValue(() => bindingData.Add(nameof(value.ExpiresAtUtc), value.ExpiresAtUtc.ToUniversalTime()));
             SafeAddValue(() => bindingData.Add(nameof(value.SystemProperties.EnqueuedTimeUtc), value.SystemProperties.EnqueuedTimeUtc));
             SafeAddValue(() => bindingData.Add(nameof(value.MessageId), value.MessageId));
             SafeAddValue(() => bindingData.Add(nameof(value.ContentType), value.ContentType));


### PR DESCRIPTION
This issue it related to Java and Python can't parse the date for ExpiresAtUtc. 
Python issue details https://github.com/Azure/azure-functions-python-worker/issues/460

We believe the issue is coming from this line [Message.cs:183](https://github.com/Azure/azure-sdk-for-net/blob/f83d1822f337c7eb2d8d4014b4932eb81a9b2979/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs#L183)
We can see this line does not return time in UTC like line 186.

This is temporary until the Service Bus SDK addresses the missing timezone issue in case DateTime.MaxValue
https://github.com/Azure/azure-sdk-for-net/issues/15343