### PR TITLE
Fix PeekAsync for ServiceBusScaleMonitor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Listeners/ServiceBusScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Listeners/ServiceBusScaleMonitor.cs
@@ -66,7 +66,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             try
             {
                 // Peek the first message in the queue without removing it from the queue
-                message = await _receiver.Value.PeekAsync();
+                // PeekAsync remembers the sequence number of the last message, so the second call returns the second message instead of the first one
+                // Use PeekBySequenceNumberAsync with fromSequenceNumber = 0 to always get the first available message
+                message = await _receiver.Value.PeekBySequenceNumberAsync(0);
 
                 if (_entityType == EntityType.Queue)
                 {

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/README.md
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/README.md
@@ -1,13 +1,13 @@
 ﻿# Service Bus Extension for Azure Functions guide to running integration tests locally
 Integration tests are implemented in the `EndToEndTests` and `SessionsEndToEndTests` classes and require special configuration to execute locally in Visual Studio or via dotnet test.  
 
-All configuration is done via a json file called `appsettings.tests` which on windows should be located in the `%USERPROFILE%\.azurefunctions` folder (e.g. `C:\Users\user123\.azurefunctions`)
+All configuration is done via a json file called `appsettings.tests.json` which on windows should be located in the `%USERPROFILE%\.azurefunctions` folder (e.g. `C:\Users\user123\.azurefunctions`)
 
 **Note:** *The specifics of the configuration will change when the validation code is modified so check the code for the latest configuration if the tests do not pass as this readme file may not have been updated with each code change.*
 
-Create the appropriate Azure resources if needed as explained below and create or update the `appsettings.tests` file in the location specified above by copying the configuration below and replacing all the `PLACEHOLDER` values
+Create the appropriate Azure resources if needed as explained below and create or update the `appsettings.tests.json` file in the location specified above by copying the configuration below and replacing all the `PLACEHOLDER` values
 
-appsettings.tests contents
+appsettings.tests.json contents
 ```
 {
     "ConnectionStrings": {


### PR DESCRIPTION
As suggested by Service Bus team in the service bus runtime driven scaling investigation ([ICM ticket](https://portal.microsofticm.com/imp/v3/incidents/details/202193612/home)),

 ```message = await _receiver.Value.PeekAsync()```

 intends to peek the first message . However, in this usage, the client remembera the sequence number of the last message and peeks the next message on the next call. For example, if there are two messages in the queue, calling peekAsync returns the first message. If you call peekAsync again, it returns the second message. If you call peekAsync again, it will return no message or null. 

Use PeekBySequenceNumberAsync instead so it forces the client to check the first message from sequence number =0. 

Repro:
1. drop two message on the service bus queue/topic
2. reuse the service bus message receiver and call peek async three times

Repro-ed and verified the PeekBySequenceNumberAsync would switch to the desired behavior. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR. Update [documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=csharp) to reflect new configuration options
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)