### PR TITLE
Upgraded to version 4.2.1 of Microsoft.Azure.ServiceBus dependency

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,10 @@
+### Release notes
+<!-- Please add your release notes in the following format:
+- My change description (#PR)
+-->
+#### Version 4.2.1
+-  Upgraded to version 4.2.1 of Microsoft.Azure.ServiceBus dependency (PR# 133)
+-  Bug fix in scaling related metrics gathering logic (PR# 121)
+
+**Release sprint:** Sprint 94
+[ [bugs](https://github.com/Azure/azure-functions-servicebus-extension/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+94%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-servicebus-extension/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+94%22+label%3Afeature+is%3Aclosed) ]

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.ServiceBus</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.ServiceBus</PackageId>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>4.2.0</Version>
+    <Version>4.2.1</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.19" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Sources" Version="3.0.19" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/README.md
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/README.md
@@ -3,7 +3,7 @@ Integration tests are implemented in the `EndToEndTests` and `SessionsEndToEndTe
 
 All configuration is done via a json file called `appsettings.tests.json` which on windows should be located in the `%USERPROFILE%\.azurefunctions` folder (e.g. `C:\Users\user123\.azurefunctions`)
 
-**Note:** *The specifics of the configuration will change when the validation code is modified so check the code for the latest configuration if the tests do not pass as this readme file may not have been updated with each code change.*
+**Note:** *The specifics of the configuration may change when validation code is modified so check the code for the latest configuration settings if tests do not pass in case this readme file was not updated.*
 
 Create the appropriate Azure resources if needed as explained below and create or update the `appsettings.tests.json` file in the location specified above by copying the configuration below and replacing all the `PLACEHOLDER` values
 
@@ -28,7 +28,7 @@ Create two service bus namespaces and configure their connection strings in `Con
 2. In the namespace configured into `ConnectionStrings:ServiceBus`, create topics and subscriptions with the following names:
     1. `core-test-topic1` with two subscriptions: `sub1` and `sub2`
     2. `core-test-topic1-sessions` with one subscription: `sub1-sessions` (enable sessions in the subscription when creating)
-2. In the namespace configured into `ConnectionStrings:ServiceBusSecondary`, create queues with the following names:
+3. In the namespace configured into `ConnectionStrings:ServiceBusSecondary`, create a queue with the following name:
     1. `core-test-queue1`
 
-  Change the message lock duration setting on all queues and subscriptions to 5 minutes to all for delays associated with stepping through code in debug mode.
+Change the message lock duration setting on all queues and topic subscriptions to 5 minutes to allow for delays associated with stepping through code in debug mode.

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/WebJobs.Extensions.ServiceBus.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/WebJobs.Extensions.ServiceBus.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.19" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
A bug was identified and fixed in the AMQP library used by the Service Bus SDK this extension relies on.  Version 4.2.1 of the Service Bus SDK links to the updated version of AMQP and this PR upgrades the extension to that version to pickup the fix.

Details of the AMQP fix can be found here: [Azure/azure-amqp release 2.4.9](https://github.com/Azure/azure-amqp/releases/tag/v2.4.9)

**Validation**: No code changes to the extension.  Existing Unit and integration tests will check for potential regression introduced by the upgraded dependency.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR. Update [documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=csharp) to reflect new configuration options
* [] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)