### PR TITLE
Added logging function name on ServiceBus exception. (#162)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,9 +2,8 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-#### Version Version 4.3.0
-- Added support for allowing 'autoComplete' setting at the function level for all the single, batch or session triggers.
+#### Version Version 4.3.1
+- Added logging function name on ServiceBus exception.
 
-
-**Release sprint:** Sprint 100
-[ [features](https://github.com/Azure/azure-functions-servicebus-extension/issues/138) ]
+**Release sprint:** Sprint 101
+[ [features](https://github.com/Azure/azure-functions-servicebus-extension/issues/162) ]

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Config/ServiceBusExtensionConfigProvider.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.ServiceBus.Bindings;
 using Microsoft.Azure.WebJobs.ServiceBus.Triggers;
 using Microsoft.Extensions.Configuration;
@@ -68,12 +67,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
                 throw new ArgumentNullException("context");
             }
 
-            // Set the default exception handler for background exceptions
-            // coming from MessageReceivers.
-            Options.ExceptionHandler = (e) =>
-            {
-                LogExceptionReceivedEvent(e, _loggerFactory);
-            };
+
 
             context
                 .AddConverter<Message, string>(new MessageToStringConverter())
@@ -88,40 +82,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Config
             // register our binding provider
             ServiceBusAttributeBindingProvider bindingProvider = new ServiceBusAttributeBindingProvider(_nameResolver, _options, _configuration, _messagingProvider);
             context.AddBindingRule<ServiceBusAttribute>().Bind(bindingProvider);
-        }
-
-        internal static void LogExceptionReceivedEvent(ExceptionReceivedEventArgs e, ILoggerFactory loggerFactory)
-        {
-            try
-            {
-                var ctxt = e.ExceptionReceivedContext;
-                var logger = loggerFactory?.CreateLogger(LogCategories.Executor);
-                string message = $"Message processing error (Action={ctxt.Action}, ClientId={ctxt.ClientId}, EntityPath={ctxt.EntityPath}, Endpoint={ctxt.Endpoint})";
-
-                var logLevel = GetLogLevel(e.Exception);
-                logger?.Log(logLevel, 0, message, e.Exception, (s, ex) => message);
-            }
-            catch
-            {
-                // best effort logging
-            }
-        }
-
-        private static LogLevel GetLogLevel(Exception ex)
-        {
-            var sbex = ex as ServiceBusException;
-            if (!(ex is OperationCanceledException) && (sbex == null || !sbex.IsTransient))
-            {
-                // any non-transient exceptions or unknown exception types
-                // we want to log as errors
-                return LogLevel.Error;
-            }
-            else
-            {
-                // transient messaging errors we log as info so we have a record
-                // of them, but we don't treat them as actual errors
-                return LogLevel.Information;
-            }
-        }        
+        } 
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerAttributeBindingProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Azure.WebJobs.ServiceBus.Listeners;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Logging;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
 {
@@ -110,18 +111,53 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Triggers
         /// <param name="functionName">The function name.</param>
         private ServiceBusOptions GetServiceBusOptions(ServiceBusTriggerAttribute attribute, string functionName)
         {
+            var options = ServiceBusOptions.DeepClone(_options);
+            options.ExceptionHandler += (e) =>
+            {
+                LogExceptionReceivedEvent(e, functionName, _loggerFactory);
+            };
+
             if (attribute.IsAutoCompleteOptionSet)
             {
-                var options = ServiceBusOptions.DeepClone(_options);
-
                 _logger.LogInformation($"The 'AutoComplete' option has been overrriden to '{attribute.AutoComplete}' value for '{functionName}' function.");
-
                 options.BatchOptions.AutoComplete = options.MessageHandlerOptions.AutoComplete = options.SessionHandlerOptions.AutoComplete = attribute.AutoComplete;
-
-                return options;
             }
+            return options;
+        }
 
-            return _options;
+        
+        internal static void LogExceptionReceivedEvent(ExceptionReceivedEventArgs e, string functionName, ILoggerFactory loggerFactory)
+        {
+            try
+            {
+                var ctxt = e.ExceptionReceivedContext;
+                var logger = loggerFactory?.CreateLogger(LogCategories.CreateFunctionCategory(functionName));
+                string message = $"Message processing error (Action={ctxt.Action}, ClientId={ctxt.ClientId}, EntityPath={ctxt.EntityPath}, Endpoint={ctxt.Endpoint})";
+
+                var logLevel = GetLogLevel(e.Exception);
+                logger?.Log(logLevel, 0, message, e.Exception, (s, ex) => message);
+            }
+            catch
+            {
+                // best effort logging
+            }
+        }
+
+        private static LogLevel GetLogLevel(Exception ex)
+        {
+            var sbex = ex as ServiceBusException;
+            if (!(ex is OperationCanceledException) && (sbex == null || !sbex.IsTransient))
+            {
+                // any non-transient exceptions or unknown exception types
+                // we want to log as errors
+                return LogLevel.Error;
+            }
+            else
+            {
+                // transient messaging errors we log as info so we have a record
+                // of them, but we don't treat them as actual errors
+                return LogLevel.Information;
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerInput.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         TriggerValue = this,
                         TriggerDetails = new Dictionary<string, string>()
                         {
+                            { "Count", "1"},
                             { "MessageId", message.MessageId },
                             { "SequenceNumber",  message.SystemProperties.SequenceNumber.ToString() },
                             { "DeliveryCount", message.SystemProperties.DeliveryCount.ToString() },
@@ -102,6 +103,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         TriggerValue = this,
                         TriggerDetails = new Dictionary<string, string>()
                         {
+                            { "Count", Messages.Length.ToString()},
                             { "MessageIdArray", string.Join(",", messageIds)},
                             { "SequenceNumberArray", string.Join(",", sequenceNumbers)},
                             { "DeliveryCountArray", string.Join(",", deliveryCounts) },

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.ServiceBus</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.ServiceBus</PackageId>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Config/ServiceBusOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Config/ServiceBusOptionsTests.cs
@@ -41,50 +41,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Config
         }
 
         [Fact]
-        public void LogExceptionReceivedEvent_NonTransientEvent_LoggedAsError()
-        {
-            var ex = new ServiceBusException(false);
-            Assert.False(ex.IsTransient);
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-        }
-
-        [Fact]
-        public void LogExceptionReceivedEvent_TransientEvent_LoggedAsInformation()
-        {
-            var ex = new ServiceBusException(true);
-            Assert.True(ex.IsTransient);
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-        }
-
-        [Fact]
-        public void LogExceptionReceivedEvent_NonMessagingException_LoggedAsError()
-        {
-            var ex = new MissingMethodException("What method??");
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-        }
-
-        [Fact]
         public void DeepClone()
         {
             var options = new ServiceBusOptions();


### PR DESCRIPTION
This change is needed for the ServiceBus detector to filter ServiceBus SDK exceptions by function name.
Previously all error which came for ServiceBus was logged under `LogCategories.Executor` category. The PR changes the category to `LogCategories.CreateFunctionCategory(functionName)` to populate `FunctionName` column in FunctionLogs.


### Pull request checklist
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR. Update [documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=csharp) to reflect new configuration options
* [] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - No new tests needed