### PR TITLE
Alrod/revert function name

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,10 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+#### Version Version 4.3.1
+- Add listener details (#186)
+- Fix batch receive race condition (#184)
+
 #### Version Version 4.3.0
 - Added support for allowing 'autoComplete' setting at the function level for all the single, batch or session triggers.
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,8 +2,9 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-#### Version Version 4.3.1
-- Added logging function name on ServiceBus exception.
+#### Version Version 4.3.0
+- Added support for allowing 'autoComplete' setting at the function level for all the single, batch or session triggers.
 
-**Release sprint:** Sprint 101
-[ [features](https://github.com/Azure/azure-functions-servicebus-extension/issues/162) ]
+
+**Release sprint:** Sprint 100
+[ [features](https://github.com/Azure/azure-functions-servicebus-extension/issues/138) ]

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerInput.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Triggers/ServiceBusTriggerInput.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         TriggerValue = this,
                         TriggerDetails = new Dictionary<string, string>()
                         {
-                            { "Count", "1"},
                             { "MessageId", message.MessageId },
                             { "SequenceNumber",  message.SystemProperties.SequenceNumber.ToString() },
                             { "DeliveryCount", message.SystemProperties.DeliveryCount.ToString() },
@@ -103,7 +102,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
                         TriggerValue = this,
                         TriggerDetails = new Dictionary<string, string>()
                         {
-                            { "Count", Messages.Length.ToString()},
                             { "MessageIdArray", string.Join(",", messageIds)},
                             { "SequenceNumberArray", string.Join(",", sequenceNumbers)},
                             { "DeliveryCountArray", string.Join(",", deliveryCounts) },

--- a/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/WebJobs.Extensions.ServiceBus.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.ServiceBus</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.ServiceBus</PackageId>
     <Description>Microsoft Azure WebJobs SDK ServiceBus Extension</Description>
-    <Version>4.3.1</Version>
+    <Version>4.3.0</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>

--- a/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests/Bindings/ServiceBusTriggerAttributeBindingProviderTests.cs
@@ -18,8 +18,6 @@ using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
-using Microsoft.Extensions.Logging;
-using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
 {
@@ -30,8 +28,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
         private readonly IConfiguration _configuration;
         private readonly string _connectionString;
         private readonly ServiceBusOptions _options;
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly TestLoggerProvider _loggerProvider;
 
         public ServiceBusTriggerAttributeBindingProviderTests()
         {
@@ -58,10 +54,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Mock<IConverterManager> convertManager = new Mock<IConverterManager>(MockBehavior.Default);
 
             _provider = new ServiceBusTriggerAttributeBindingProvider(mockResolver.Object, _options, _mockMessagingProvider.Object, _configuration, NullLoggerFactory.Instance, convertManager.Object);
-
-            _loggerFactory = new LoggerFactory();
-            _loggerProvider = new TestLoggerProvider();
-            _loggerFactory.AddProvider(_loggerProvider);
         }
 
         [Fact]
@@ -117,52 +109,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Bindings
             Assert.False(listenerOptions.BatchOptions.AutoComplete);
         }
 
-        [Fact]
-        public void LogExceptionReceivedEvent_NonTransientEvent_LoggedAsError()
-        {
-            var ex = new ServiceBusException(false);
-            Assert.False(ex.IsTransient);
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusTriggerAttributeBindingProvider.LogExceptionReceivedEvent(e, "TestFunction", _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);            
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-            Assert.True(logMessage.Category.Contains("TestFunction"));
-        }
-
-        [Fact]
-        public void LogExceptionReceivedEvent_TransientEvent_LoggedAsInformation()
-        {
-            var ex = new ServiceBusException(true);
-            Assert.True(ex.IsTransient);
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusTriggerAttributeBindingProvider.LogExceptionReceivedEvent(e, "TestFunction", _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-            Assert.True(logMessage.Category.Contains("TestFunction"));
-        }
-
-        [Fact]
-        public void LogExceptionReceivedEvent_NonMessagingException_LoggedAsError()
-        {
-            var ex = new MissingMethodException("What method??");
-            ExceptionReceivedEventArgs e = new ExceptionReceivedEventArgs(ex, "TestAction", "TestEndpoint", "TestEntity", "TestClient");
-            ServiceBusTriggerAttributeBindingProvider.LogExceptionReceivedEvent(e, "TestFunction", _loggerFactory);
-
-            var expectedMessage = $"Message processing error (Action=TestAction, ClientId=TestClient, EntityPath=TestEntity, Endpoint=TestEndpoint)";
-            var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-            Assert.True(logMessage.Category.Contains("TestFunction"));
-        }
         public static void TestJob_AccountOverride(
             [ServiceBusTriggerAttribute("test"),
              ServiceBusAccount(Constants.DefaultConnectionStringName)] Message message)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR reverts the commit:
https://github.com/Azure/azure-functions-servicebus-extension/commit/cd7528ae4aab8ba90531a90e33e41b4e46cc4801

We do not need this change anymore as the ServiceBus SDK errors can be correlated with function name by details logged on listener start up.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)



